### PR TITLE
Use process.env.PORT if given

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import express from "express";
 import { register } from "./api/generated";
 import imdb from "./services/imdb";
 
-const PORT = 8080;
+const PORT = process.env.PORT || 8080;
 
 const app = express();
 


### PR DESCRIPTION
For an express starter kit like this, I think the server should use process.env.PORT if given. This is common for heroku-like projects. See: https://stackoverflow.com/questions/15693192/heroku-node-js-error-web-process-failed-to-bind-to-port-within-60-seconds-of.