### PR TITLE
Use fern-api/setup-fern-cli@v1 action in check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install fern
-        run: npm install -g fern-api
+      - name: Setup Fern CLI
+        uses: fern-api/setup-fern-cli@v1
       - name: fern generate
         run: fern generate
         env:


### PR DESCRIPTION
## Summary

- Replaces the `npm install -g fern-api` run step with the `fern-api/setup-fern-cli@v1` GitHub Action in `.github/workflows/check.yml`
- No `setup-node` step is needed since GitHub-hosted `ubuntu-latest` runners include Node.js by default, which satisfies the action's requirement

## Test plan

- [ ] Verify the `check` workflow runs successfully on this PR
- [ ] Confirm Fern CLI is available in subsequent steps (e.g., `fern generate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)